### PR TITLE
Build near filter when key is an array

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -768,31 +768,63 @@ function convertToMeters(distance, unit) {
   }
 }
 
-function buildNearFilter(query, near) {
-  var coordinates = {};
-  if (typeof near.near === 'string') {
-    var s = near.near.split(',');
-    coordinates.lng = Number(s[0]);
-    coordinates.lat = Number(s[1]);
-  } else {
-    coordinates = near.near;
+function buildNearFilter(query, params) {
+  if (!Array.isArray(params)) {
+    params = [params];
   }
 
-  query.where[near.key] = {
-    near: {
-      $geometry: {
-        coordinates: [coordinates.lng, coordinates.lat],
-        type: 'Point',
-      },
-    },
-  };
+  params.forEach(function (near) {
+    var coordinates = {};
 
-  var props = ['maxDistance', 'minDistance'];
-  //use mongodb default unit 'meters' rather than 'miles'
-  var unit = near.unit || 'meters';
-  props.forEach(function(p) {
-    if (near[p]) {
-      query.where[near.key]['near']['$' + p] = convertToMeters(near[p], unit);
+    if (typeof near.near === 'string') {
+      var s = near.near.split(',');
+      coordinates.lng = Number(s[0]);
+      coordinates.lat = Number(s[1]);
+    } else {
+      coordinates = near.near;
+    }
+
+    var props = ['maxDistance', 'minDistance'];
+    //use mongodb default unit 'meters' rather than 'miles'
+    var unit = near.unit || 'meters';
+
+    var queryValue = {
+      near: {
+        $geometry: {
+          coordinates: [coordinates.lng, coordinates.lat],
+          type: 'Point',
+        },
+      },
+    };
+
+    props.forEach(function(p) {
+      if (near[p]) {
+        queryValue['near']['$' + p] = convertToMeters(near[p], unit);
+      }
+    });
+
+    var property;
+
+    if (near.key) {
+      if (Array.isArray(near.key)) {
+        property = query.where;
+
+        for (var i=0; i<near.key.length; i++) {
+          var subKey = near.key[i];
+          if (near.key.hasOwnProperty(i + 1)) {
+            if (!property.hasOwnProperty(subKey)) {
+              property[subKey] = Number.isInteger(near.key[i + 1]) ? [] : {};
+            }
+
+            property = property[subKey];
+          }
+        }
+
+        property[near.key[i - 1]] = queryValue;
+      }
+      else {
+        property = query.where[near.key] = queryValue;
+      }
     }
   });
 };


### PR DESCRIPTION
### Description

In some cases, the key given to build the `$near` filter can be an array, so that this filter isn't limited to first-level keys (each non-empty item in the array is a new level of depth).

This fix should be able to handle that.

#### Related issues

strongloop/loopback-datasource-juggler/pull/993

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)